### PR TITLE
feat(http): add Runpod Flash User-Agent to cross-endpoint requests

### DIFF
--- a/src/remote_executor.py
+++ b/src/remote_executor.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import List, Any, Optional
 import aiohttp
+from runpod_flash.core.utils.user_agent import get_user_agent
 from runpod_flash.protos.remote_execution import (
     FunctionRequest,
     FunctionResponse,
@@ -450,7 +451,10 @@ class RemoteExecutor(RemoteExecutorStub):
 
             # Make HTTP request to target endpoint
             api_key = os.getenv("RUNPOD_API_KEY")
-            headers = {"Content-Type": "application/json"}
+            headers = {
+                "Content-Type": "application/json",
+                "User-Agent": get_user_agent(),
+            }
 
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"

--- a/tests/unit/test_remote_executor.py
+++ b/tests/unit/test_remote_executor.py
@@ -588,6 +588,48 @@ class TestRemoteExecutor:
             mock_registry.get_endpoint_for_function.assert_called_once_with("my_func")
 
     @pytest.mark.asyncio
+    async def test_cross_endpoint_routing_includes_user_agent_header(self):
+        """HTTP requests to remote endpoints must include Runpod Flash User-Agent."""
+        request = FunctionRequest(function_name="my_func")
+
+        with (
+            patch("remote_executor.ServiceRegistry") as mock_registry_class,
+            patch("remote_executor.refresh_manifest_if_stale") as mock_refresh,
+            patch("aiohttp.ClientSession") as mock_session_class,
+        ):
+            mock_registry = AsyncMock()
+            mock_registry.is_local_function = Mock(return_value=False)
+            mock_registry.get_endpoint_for_function = AsyncMock(
+                return_value="https://api.runpod.ai/v2/endpoint-xyz789/run"
+            )
+            mock_registry_class.return_value = mock_registry
+            self.executor.service_registry = mock_registry
+            mock_refresh.return_value = True
+
+            # Mock the session context manager and post call
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(
+                return_value={"output": {"success": True, "result": "ok"}}
+            )
+            mock_response.__aenter__.return_value = mock_response
+            mock_response.__aexit__.return_value = None
+
+            mock_session = AsyncMock()
+            mock_session.post.return_value = mock_response
+            mock_session.__aenter__.return_value = mock_session
+            mock_session.__aexit__.return_value = None
+            mock_session_class.return_value = mock_session
+
+            await self.executor.ExecuteFunction(request)
+
+            # Extract headers passed to session.post
+            call_args = mock_session.post.call_args
+            headers = call_args.kwargs.get("headers") or call_args[1].get("headers")
+            assert "User-Agent" in headers
+            assert "Runpod Flash/" in headers["User-Agent"]
+
+    @pytest.mark.asyncio
     async def test_execute_function_flash_local_execution_with_service_registry(self):
         """Test ExecuteFunction executes locally when ServiceRegistry identifies local function."""
         request = FunctionRequest(function_name="my_func")


### PR DESCRIPTION
## Summary

- Cross-endpoint HTTP dispatch in `_route_to_endpoint` was missing a `User-Agent` header
- Added `Runpod Flash/<version>` User-Agent via `get_user_agent()` from `runpod_flash.core.utils.user_agent`
- Added test verifying header presence on remote endpoint calls

## Test plan

- [x] New unit test `test_cross_endpoint_routing_includes_user_agent_header` verifies `User-Agent` contains `Runpod Flash/`
- [x] All 277 tests pass, 81% coverage
- [x] Pre-commit quality checks pass (format, lint, mypy, tests)