### PR TITLE
feat: multi-Python worker images with startup version check (AE-2827)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
   docker-test:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -89,19 +92,22 @@ jobs:
           push: false
           tags: flash-cpu:test
           build-args: |
-            PYTHON_VERSION=3.11
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=cpu-test-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=cpu-test-py${{ matrix.python-version }}
           load: true
 
       - name: Test CPU handler execution in Docker environment
         run: |
-          echo "Testing CPU handler in Docker environment..."
+          echo "Testing CPU handler (Python ${{ matrix.python-version }})..."
           docker run --rm flash-cpu:test ./test-handler.sh
 
   docker-test-lb-cpu:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -118,24 +124,97 @@ jobs:
           push: false
           tags: flash-lb-cpu:test
           build-args: |
-            PYTHON_VERSION=3.11
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=lb-cpu-test-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=lb-cpu-test-py${{ matrix.python-version }}
           load: true
 
       - name: Test LB handler execution in Docker environment
         run: |
-          echo "Testing LB handler in Docker environment..."
+          echo "Testing LB handler (Python ${{ matrix.python-version }})..."
           docker run --rm flash-lb-cpu:test ./test-lb-handler.sh
+
+  docker-test-gpu:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Clear space
+        run: |
+          rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
+          df -h
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build GPU Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: flash-gpu:test
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=gpu-test-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=gpu-test-py${{ matrix.python-version }}
+
+  docker-test-lb:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Clear space
+        run: |
+          rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
+          df -h
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build GPU Load Balancer Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile-lb
+          platforms: linux/amd64
+          push: false
+          tags: flash-lb:test
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=lb-test-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=lb-test-py${{ matrix.python-version }}
 
   docker-validation:
     runs-on: ubuntu-latest
-    needs: [test, lint, docker-test, docker-test-lb-cpu]
+    needs: [test, lint, docker-test, docker-test-lb-cpu, docker-test-gpu, docker-test-lb]
     if: always()
     steps:
       - name: Check all jobs succeeded
         run: |
-          results=("${{ needs.test.result }}" "${{ needs.lint.result }}" "${{ needs.docker-test.result }}" "${{ needs.docker-test-lb-cpu.result }}")
+          results=(
+            "${{ needs.test.result }}"
+            "${{ needs.lint.result }}"
+            "${{ needs.docker-test.result }}"
+            "${{ needs.docker-test-lb-cpu.result }}"
+            "${{ needs.docker-test-gpu.result }}"
+            "${{ needs.docker-test-lb.result }}"
+          )
           for result in "${results[@]}"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "One or more quality checks failed (got: $result)"
@@ -168,8 +247,13 @@ jobs:
     needs: [release]
     if: needs.release.outputs.release_created
     strategy:
+      fail-fast: false
       matrix:
         include:
+          - python-version: "3.10"
+            is-default: false
+          - python-version: "3.11"
+            is-default: false
           - python-version: "3.12"
             is-default: true
     steps:
@@ -226,22 +310,25 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha,scope=gpu
-          cache-to: type=gha,mode=max,scope=gpu
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=gpu-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=gpu-py${{ matrix.python-version }}
 
   docker-prod-cpu:
     runs-on: ubuntu-latest
     needs: [release]
     if: needs.release.outputs.release_created
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.10"
             is-default: false
           - python-version: "3.11"
-            is-default: true
-          - python-version: "3.12"
             is-default: false
+          - python-version: "3.12"
+            is-default: true
     steps:
       - name: Clear Space
         run: |
@@ -306,8 +393,13 @@ jobs:
     needs: [release]
     if: needs.release.outputs.release_created
     strategy:
+      fail-fast: false
       matrix:
         include:
+          - python-version: "3.10"
+            is-default: false
+          - python-version: "3.11"
+            is-default: false
           - python-version: "3.12"
             is-default: true
     steps:
@@ -364,22 +456,25 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
-          cache-from: type=gha,scope=lb
-          cache-to: type=gha,mode=max,scope=lb
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+          cache-from: type=gha,scope=lb-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=lb-py${{ matrix.python-version }}
 
   docker-prod-lb-cpu:
     runs-on: ubuntu-latest
     needs: [release]
     if: needs.release.outputs.release_created
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.10"
             is-default: false
           - python-version: "3.11"
-            is-default: true
-          - python-version: "3.12"
             is-default: false
+          - python-version: "3.12"
+            is-default: true
     steps:
       - name: Clear Space
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-# Base image provides Python 3.9-3.13 via deadsnakes; only 3.12 has torch
-# pre-installed. For 3.10 and 3.11 we reinstall torch from the CUDA 12.8
-# wheel index (~7 GB overhead) and repoint /usr/local/bin/python so the
-# worker CMD picks up the correct interpreter.
+# Base image (runpod/pytorch:ubuntu2204) ships Ubuntu 22.04 system python3.10
+# plus alt-Python interpreters for 3.11/3.12 with torch pre-installed on 3.12.
+# For non-3.12 targets we reinstall torch from the CUDA 12.8 wheel index
+# (~7 GB overhead) and repoint /usr/local/bin/python so the worker CMD picks
+# up the correct interpreter.
 FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204
 
 # Target Python version for the worker runtime.
@@ -17,9 +18,15 @@ ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
 # /usr/local/bin/python and python3 so downstream `python` invocations use it.
 # For 3.12 we keep the base image's python/torch untouched to avoid the
 # ~7 GB reinstall cost.
+#
+# pip bootstrap: Ubuntu 22.04's system python3.10 has ensurepip disabled by
+# Debian policy, so we install pip via get-pip.py (works for any interpreter
+# regardless of distro patching). urllib is stdlib, avoiding a curl dependency.
 RUN python${PYTHON_VERSION} --version \
  && if [ "${PYTHON_VERSION}" != "3.12" ]; then \
-      python${PYTHON_VERSION} -m ensurepip --upgrade \
+      python${PYTHON_VERSION} -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', '/tmp/get-pip.py')" \
+      && python${PYTHON_VERSION} /tmp/get-pip.py --no-cache-dir \
+      && rm -f /tmp/get-pip.py \
       && python${PYTHON_VERSION} -m pip install --no-cache-dir \
            --index-url ${TORCH_INDEX_URL} \
            "torch==${TORCH_VERSION}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,30 @@
-# Base image provides Python 3.12 (from runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204)
+# Base image provides Python 3.9-3.13 via deadsnakes; only 3.12 has torch
+# pre-installed. For 3.10 and 3.11 we reinstall torch from the CUDA 12.8
+# wheel index (~7 GB overhead) and repoint /usr/local/bin/python so the
+# worker CMD picks up the correct interpreter.
 FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204
 
-# Use the base image's Python as-is to preserve pre-installed packages (torch, cuda libs).
-# The pytorch base image provides its own Python with torch already installed.
-# Symlinking to /usr/bin/python3.X would switch to a bare system Python without torch.
-# Validate that the base image provides the expected Python version.
-ARG EXPECTED_PYTHON_VERSION=3.12
-RUN python --version && \
-    actual=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") && \
-    if [ "$actual" != "$EXPECTED_PYTHON_VERSION" ]; then \
-      echo "ERROR: Expected Python $EXPECTED_PYTHON_VERSION but base image provides $actual" && exit 1; \
+# Target Python version for the worker runtime.
+ARG PYTHON_VERSION=3.12
+ARG TORCH_VERSION=2.9.1+cu128
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+# Expose the target version to the running worker for startup validation.
+ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
+
+# Validate the base image provides the requested interpreter and activate it.
+# For non-3.12 targets, install torch for the selected Python and repoint
+# /usr/local/bin/python and python3 so downstream `python` invocations use it.
+# For 3.12 we keep the base image's python/torch untouched to avoid the
+# ~7 GB reinstall cost.
+RUN python${PYTHON_VERSION} --version \
+ && if [ "${PYTHON_VERSION}" != "3.12" ]; then \
+      python${PYTHON_VERSION} -m ensurepip --upgrade \
+      && python${PYTHON_VERSION} -m pip install --no-cache-dir \
+           --index-url ${TORCH_INDEX_URL} \
+           "torch==${TORCH_VERSION}" \
+      && ln -sf "$(which python${PYTHON_VERSION})" /usr/local/bin/python \
+      && ln -sf "$(which python${PYTHON_VERSION})" /usr/local/bin/python3; \
     fi
 
 WORKDIR /app
@@ -41,20 +56,21 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
  && rm -rf /var/lib/apt/lists/*
 
 # Copy app code and install dependencies
-# Use --python to target the base image's Python (preserves torch in its site-packages)
+# Use --python to target the active interpreter (preserves torch in its site-packages)
 COPY README.md pyproject.toml uv.lock ./
 COPY src/ ./
 RUN uv export --format requirements-txt --no-dev --no-hashes > requirements.txt \
  && uv pip install --python $(which python) --break-system-packages -r requirements.txt
 
-# Install numpy for the base image's Python version.
+# Install numpy for the active Python version.
 # The runpod/pytorch image ships torch but not numpy. Flash build excludes numpy
 # from tarballs (BASE_IMAGE_PACKAGES) to save tarball space (~30 MB), so numpy
 # must be provided here in the base image.
 RUN python -m pip install --no-cache-dir numpy
 
-# Verify torch and numpy are available from the base image
-RUN python -c "import torch; print(f'torch {torch.__version__} CUDA {torch.cuda.is_available()}')" \
+# Verify torch, numpy, and the expected Python version are available.
+RUN python -c "import sys; actual = f'{sys.version_info.major}.{sys.version_info.minor}'; expected = '${PYTHON_VERSION}'; assert actual == expected, f'Expected Python {expected}, got {actual}'; print(f'Python {actual} OK')" \
+ && python -c "import torch; print(f'torch {torch.__version__} CUDA {torch.cuda.is_available()}')" \
  && python -c "import numpy; print(f'numpy {numpy.__version__}')"
 
 CMD ["python", "handler.py"]

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,6 +1,11 @@
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 
+# Re-declare after FROM so the value is visible in this build stage, and
+# expose it at runtime for the worker's startup version check.
+ARG PYTHON_VERSION
+ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
+
 WORKDIR /app
 
 # Prevent interactive prompts during package installation

--- a/Dockerfile-lb
+++ b/Dockerfile-lb
@@ -1,7 +1,8 @@
-# Base image provides Python 3.9-3.13 via deadsnakes; only 3.12 has torch
-# pre-installed. For 3.10 and 3.11 we reinstall torch from the CUDA 12.8
-# wheel index (~7 GB overhead) and repoint /usr/local/bin/python so the
-# worker CMD picks up the correct interpreter.
+# Base image (runpod/pytorch:ubuntu2204) ships Ubuntu 22.04 system python3.10
+# plus alt-Python interpreters for 3.11/3.12 with torch pre-installed on 3.12.
+# For non-3.12 targets we reinstall torch from the CUDA 12.8 wheel index
+# (~7 GB overhead) and repoint /usr/local/bin/python so the worker CMD picks
+# up the correct interpreter.
 FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204
 
 # Target Python version for the worker runtime.
@@ -17,9 +18,15 @@ ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
 # /usr/local/bin/python and python3 so downstream `python` invocations use it.
 # For 3.12 we keep the base image's python/torch untouched to avoid the
 # ~7 GB reinstall cost.
+#
+# pip bootstrap: Ubuntu 22.04's system python3.10 has ensurepip disabled by
+# Debian policy, so we install pip via get-pip.py (works for any interpreter
+# regardless of distro patching). urllib is stdlib, avoiding a curl dependency.
 RUN python${PYTHON_VERSION} --version \
  && if [ "${PYTHON_VERSION}" != "3.12" ]; then \
-      python${PYTHON_VERSION} -m ensurepip --upgrade \
+      python${PYTHON_VERSION} -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', '/tmp/get-pip.py')" \
+      && python${PYTHON_VERSION} /tmp/get-pip.py --no-cache-dir \
+      && rm -f /tmp/get-pip.py \
       && python${PYTHON_VERSION} -m pip install --no-cache-dir \
            --index-url ${TORCH_INDEX_URL} \
            "torch==${TORCH_VERSION}" \

--- a/Dockerfile-lb
+++ b/Dockerfile-lb
@@ -1,13 +1,30 @@
-# Base image provides Python 3.12 (from runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204)
+# Base image provides Python 3.9-3.13 via deadsnakes; only 3.12 has torch
+# pre-installed. For 3.10 and 3.11 we reinstall torch from the CUDA 12.8
+# wheel index (~7 GB overhead) and repoint /usr/local/bin/python so the
+# worker CMD picks up the correct interpreter.
 FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204
 
-# Use the base image's Python as-is to preserve pre-installed packages (torch, cuda libs).
-# Validate that the base image provides the expected Python version.
-ARG EXPECTED_PYTHON_VERSION=3.12
-RUN python --version && \
-    actual=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')") && \
-    if [ "$actual" != "$EXPECTED_PYTHON_VERSION" ]; then \
-      echo "ERROR: Expected Python $EXPECTED_PYTHON_VERSION but base image provides $actual" && exit 1; \
+# Target Python version for the worker runtime.
+ARG PYTHON_VERSION=3.12
+ARG TORCH_VERSION=2.9.1+cu128
+ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
+
+# Expose the target version to the running worker for startup validation.
+ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
+
+# Validate the base image provides the requested interpreter and activate it.
+# For non-3.12 targets, install torch for the selected Python and repoint
+# /usr/local/bin/python and python3 so downstream `python` invocations use it.
+# For 3.12 we keep the base image's python/torch untouched to avoid the
+# ~7 GB reinstall cost.
+RUN python${PYTHON_VERSION} --version \
+ && if [ "${PYTHON_VERSION}" != "3.12" ]; then \
+      python${PYTHON_VERSION} -m ensurepip --upgrade \
+      && python${PYTHON_VERSION} -m pip install --no-cache-dir \
+           --index-url ${TORCH_INDEX_URL} \
+           "torch==${TORCH_VERSION}" \
+      && ln -sf "$(which python${PYTHON_VERSION})" /usr/local/bin/python \
+      && ln -sf "$(which python${PYTHON_VERSION})" /usr/local/bin/python3; \
     fi
 
 WORKDIR /app
@@ -39,20 +56,21 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-ins
  && rm -rf /var/lib/apt/lists/*
 
 # Copy app code and install dependencies
-# Use --python to target the base image's Python (preserves torch in its site-packages)
+# Use --python to target the active interpreter (preserves torch in its site-packages)
 COPY README.md pyproject.toml uv.lock ./
 COPY src/ ./
 RUN uv export --format requirements-txt --no-dev --no-hashes > requirements.txt \
  && uv pip install --python $(which python) --break-system-packages -r requirements.txt
 
-# Install numpy for the base image's Python version.
+# Install numpy for the active Python version.
 # The runpod/pytorch image ships torch but not numpy. Flash build excludes numpy
 # from tarballs (BASE_IMAGE_PACKAGES) to save tarball space (~30 MB), so numpy
 # must be provided here in the base image.
 RUN python -m pip install --no-cache-dir numpy
 
-# Verify torch and numpy are available from the base image
-RUN python -c "import torch; print(f'torch {torch.__version__} CUDA {torch.cuda.is_available()}')" \
+# Verify torch, numpy, and the expected Python version are available.
+RUN python -c "import sys; actual = f'{sys.version_info.major}.{sys.version_info.minor}'; expected = '${PYTHON_VERSION}'; assert actual == expected, f'Expected Python {expected}, got {actual}'; print(f'Python {actual} OK')" \
+ && python -c "import torch; print(f'torch {torch.__version__} CUDA {torch.cuda.is_available()}')" \
  && python -c "import numpy; print(f'numpy {numpy.__version__}')"
 
 EXPOSE 80

--- a/Dockerfile-lb-cpu
+++ b/Dockerfile-lb-cpu
@@ -1,6 +1,11 @@
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 
+# Re-declare after FROM so the value is visible in this build stage, and
+# expose it at runtime for the worker's startup version check.
+ARG PYTHON_VERSION
+ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}
+
 WORKDIR /app
 
 # Prevent interactive prompts during package installation

--- a/src/handler.py
+++ b/src/handler.py
@@ -8,12 +8,16 @@ from typing import Any, Dict, Optional
 from constants import MAX_IMPORT_RECOVERY_ATTEMPTS
 from logger import setup_logging
 from unpack_volume import maybe_unpack
-from version import format_version_banner
+from version import assert_python_version_matches_image, format_version_banner
 
 # Initialize logging configuration
 setup_logging()
 
 logger = logging.getLogger(__name__)
+
+# Fail fast if the running interpreter disagrees with the image's advertised
+# version — catches mis-tagged images before user code runs.
+assert_python_version_matches_image()
 
 # Unpack Flash deployment artifacts if running in Flash mode
 # This is a no-op for Live Serverless and local development

--- a/src/lb_handler.py
+++ b/src/lb_handler.py
@@ -29,11 +29,15 @@ from fastapi import FastAPI
 
 from logger import setup_logging
 from unpack_volume import maybe_unpack
-from version import format_version_banner
+from version import assert_python_version_matches_image, format_version_banner
 
 # Initialize logging configuration
 setup_logging()
 logger = logging.getLogger(__name__)
+
+# Fail fast if the running interpreter disagrees with the image's advertised
+# version — catches mis-tagged images before user code runs.
+assert_python_version_matches_image()
 
 # Unpack Flash deployment artifacts if running in Flash mode
 # This is a no-op for Live Serverless and local development

--- a/src/version.py
+++ b/src/version.py
@@ -1,9 +1,40 @@
 """Version utilities for flash-worker boot logging."""
 
+import os
 import platform
+import sys
 from importlib.metadata import PackageNotFoundError, version
 
 __version__ = "1.4.4"  # x-release-please-version
+
+
+class PythonVersionMismatchError(RuntimeError):
+    """Raised when the running interpreter does not match the image's declared version."""
+
+
+def assert_python_version_matches_image() -> None:
+    """Fail fast if ``sys.version_info`` disagrees with ``FLASH_PYTHON_VERSION``.
+
+    The Dockerfiles stamp ``FLASH_PYTHON_VERSION`` with the image's target
+    Python (e.g. ``3.11``). If an image is mis-tagged, an apt upgrade
+    changes ``python`` symlinks, or the GPU side-by-side torch install fails
+    silently, this surfaces the skew immediately at worker boot instead of
+    letting user code fail later with a confusing ABI error.
+
+    Skips the check when ``FLASH_PYTHON_VERSION`` is unset (local dev,
+    test harnesses).
+    """
+    declared = os.environ.get("FLASH_PYTHON_VERSION")
+    if not declared:
+        return
+
+    actual = f"{sys.version_info.major}.{sys.version_info.minor}"
+    if actual != declared:
+        raise PythonVersionMismatchError(
+            f"Worker interpreter mismatch: image declares FLASH_PYTHON_VERSION="
+            f"{declared!r} but sys.version_info reports {actual!r}. "
+            f"Rebuild the image with the correct PYTHON_VERSION build arg."
+        )
 
 
 def _get_version(package_name: str) -> str:

--- a/tests/unit/test_lb_handler.py
+++ b/tests/unit/test_lb_handler.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI
 # Mock heavy dependencies before importing lb_handler to prevent side effects
 _mock_version = MagicMock()
 _mock_version.format_version_banner = MagicMock(return_value="Starting Flash Worker vtest")
+_mock_version.assert_python_version_matches_image = MagicMock(return_value=None)
 
 _MOCK_MODULES = {
     "logger": MagicMock(),

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,12 +1,17 @@
 """Tests for version utilities."""
 
 import platform
+import sys
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
+import pytest
+
 from version import (
+    PythonVersionMismatchError,
     __version__,
     _get_version,
+    assert_python_version_matches_image,
     format_version_banner,
     get_flash_version,
     get_runpod_version,
@@ -76,3 +81,36 @@ class TestFormatVersionBanner:
             result
             == f"Starting Flash Worker unknown | Python {py} | runpod-flash unknown | runpod unknown"
         )
+
+
+class TestAssertPythonVersionMatchesImage:
+    """Tests for the AE-2827 Python version assertion."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv("FLASH_PYTHON_VERSION", raising=False)
+
+    def test_noop_when_env_var_unset(self):
+        """Local dev and test harnesses don't set FLASH_PYTHON_VERSION; skip check."""
+        assert_python_version_matches_image()
+
+    def test_passes_when_declared_matches_interpreter(self, monkeypatch):
+        actual = f"{sys.version_info.major}.{sys.version_info.minor}"
+        monkeypatch.setenv("FLASH_PYTHON_VERSION", actual)
+        assert_python_version_matches_image()
+
+    def test_raises_on_mismatch(self, monkeypatch):
+        monkeypatch.setenv("FLASH_PYTHON_VERSION", "3.99")
+        with pytest.raises(PythonVersionMismatchError, match="interpreter mismatch"):
+            assert_python_version_matches_image()
+
+    def test_mismatch_error_message_includes_both_versions(self, monkeypatch):
+        declared = "3.99"
+        monkeypatch.setenv("FLASH_PYTHON_VERSION", declared)
+        with pytest.raises(PythonVersionMismatchError) as excinfo:
+            assert_python_version_matches_image()
+
+        actual = f"{sys.version_info.major}.{sys.version_info.minor}"
+        message = str(excinfo.value)
+        assert declared in message
+        assert actual in message


### PR DESCRIPTION
## Summary

Sibling to [runpod/flash#322](https://github.com/runpod/flash/pull/322). Adds Python 3.10 and 3.11 to GPU and LB images via side-by-side torch install in the `runpod/pytorch` base, expands CI to build the full {3.10, 3.11, 3.12} × {gpu, cpu, lb, lb-cpu} matrix, and fails the worker fast at boot if the interpreter doesn't match the image's advertised version.

**Marked draft** until CI has run a full green matrix — I don't have a GPU Docker daemon locally to validate the non-3.12 side-by-side torch install path.

## Design

- **3.12** keeps the existing fast path: use the base image's pre-installed Python + torch. No reinstall cost.
- **3.10 / 3.11** install torch 2.9.1+cu128 from `download.pytorch.org/whl/cu128` and repoint `/usr/local/bin/python` + `python3` to the target interpreter. Paid cold-start cost: ~7 GB one-time per DC.
- **CPU / LB-CPU** already accepted `ARG PYTHON_VERSION`; added `ENV FLASH_PYTHON_VERSION=${PYTHON_VERSION}` so the worker startup check can read it uniformly.
- **Default flip on prod-cpu / prod-lb-cpu**: the `is-default: true` entry moves from 3.11 to 3.12 to match flash's `DEFAULT_PYTHON_VERSION`. Tags like `runpod/flash-cpu:latest` now resolve to 3.12; per-version tags like `runpod/flash-cpu:py3.11-latest` are unchanged.

## Worker-side guardrail

`version.assert_python_version_matches_image()` raises `PythonVersionMismatchError` at QB + LB handler boot when `sys.version_info` disagrees with `FLASH_PYTHON_VERSION`. Catches mis-tagged images before user code runs. Skipped when the env var is unset (local dev / pytest harness).

## Test plan

- [x] `make quality-check` passes locally (all 271 unit tests + 14 handler smoke tests)
- [x] 4 new unit tests in `test_version.py` cover env-unset skip, match, mismatch raise, error-message contents
- [x] `test_lb_handler.py` mock refreshed so fresh-import tests continue to pass
- [ ] **CI: full image matrix builds green** (draft until this is confirmed — particularly the GPU side-by-side torch install for 3.10 / 3.11)
- [ ] Smoke test one non-3.12 image end-to-end: deploy a 3.11-targeted FlashApp once the image tags land on Docker Hub

## Rollout

- Merge after flash#322 so the SDK can resolve to the new image tags.
- No env-var or flag flip required for existing 3.12 users — they stay on the fast path.