### PR TITLE
ci: free more disk in docker-test-gpu/lb runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,14 @@ jobs:
     steps:
       - name: Clear space
         run: |
-          rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/dotnet \
+                      /opt/ghc /usr/local/.ghcup \
+                      /usr/local/lib/android \
+                      /usr/local/share/boost \
+                      /opt/hostedtoolcache/CodeQL \
+                      /opt/microsoft /opt/google \
+                      /imagegeneration \
+                      "$AGENT_TOOLSDIRECTORY"
           docker system prune -af
           df -h
 
@@ -177,7 +184,14 @@ jobs:
     steps:
       - name: Clear space
         run: |
-          rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /usr/share/dotnet \
+                      /opt/ghc /usr/local/.ghcup \
+                      /usr/local/lib/android \
+                      /usr/local/share/boost \
+                      /opt/hostedtoolcache/CodeQL \
+                      /opt/microsoft /opt/google \
+                      /imagegeneration \
+                      "$AGENT_TOOLSDIRECTORY"
           docker system prune -af
           df -h
 


### PR DESCRIPTION
## Summary

- The multi-Python rollout in #89 added a ~7 GB torch reinstall to `Dockerfile` and `Dockerfile-lb` when `PYTHON_VERSION != 3.12`. The Dockerfile header openly notes the overhead.
- Recent `main` CI runs (e.g. [25080308087](https://github.com/runpod-workers/flash/actions/runs/25080308087), [25079769003](https://github.com/runpod-workers/flash/actions/runs/25079769003)) fail in `docker-test-lb (3.11)` and `docker-test-gpu (3.11)` with `OSError: [Errno 28] No space left on device` while pip downloads `torch-2.9.1+cu128-cp311` (~901 MB wheel) on top of the base image's already-installed cp312 torch. The trailing `System.IO.IOException` in the run summary is collateral — the runner can't even flush its diagnostic log.
- The existing ``Clear space`` step only reclaims ~13 GB. Adding the Android SDK, CodeQL toolcache, ``.ghcup``, and the Microsoft/Google language toolchains reclaims roughly +25 GB, comfortably covering the ~7 GB torch install plus GHA cache headroom.
- ``sudo`` is required because the preinstalled toolchains are owned by root; without it the existing line was already silently failing on protected paths.

Same change applied to both ``docker-test-gpu`` and ``docker-test-lb`` jobs (the only two that build the heavyweight pytorch base image).

## Test plan

- [ ] CI: ``docker-test-lb (3.10/3.11/3.12)`` all green on this PR
- [ ] CI: ``docker-test-gpu (3.10/3.11/3.12)`` all green on this PR
- [ ] CI: ``docker-validation`` passes (gates the release pipeline that's been stuck since #89)
- [ ] Local: ``make quality-check`` passes (281 unit + 14 handler tests, 81% coverage) ✅