### PR TITLE
feat(worker): publish py3.13 image variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Clear space
         run: |
@@ -180,7 +180,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Clear space
         run: |
@@ -270,6 +270,8 @@ jobs:
             is-default: false
           - python-version: "3.12"
             is-default: true
+          - python-version: "3.13"
+            is-default: false
     steps:
       - name: Clear Space
         run: |
@@ -343,6 +345,8 @@ jobs:
             is-default: false
           - python-version: "3.12"
             is-default: true
+          - python-version: "3.13"
+            is-default: false
     steps:
       - name: Clear Space
         run: |
@@ -416,6 +420,8 @@ jobs:
             is-default: false
           - python-version: "3.12"
             is-default: true
+          - python-version: "3.13"
+            is-default: false
     steps:
       - name: Clear Space
         run: |
@@ -489,6 +495,8 @@ jobs:
             is-default: false
           - python-version: "3.12"
             is-default: true
+          - python-version: "3.13"
+            is-default: false
     steps:
       - name: Clear Space
         run: |


### PR DESCRIPTION
## Summary

Adds Python 3.13 to the worker image CI matrix. **No Dockerfile changes required** — the base image `runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204` already ships `python3.13` at `/usr/bin/python3.13` (verified via `docker run ... python3.13 --version` → `Python 3.13.11`). The existing non-3.12 install path (pip bootstrap + torch reinstall + symlink repoint) handles 3.13 unchanged.

## What's in this PR

`.github/workflows/ci.yml`: 3.13 added to the four `docker-test-*` matrices (build/test) and to the four `docker-prod-*` include-style matrices (release-build). One commit, +12/-4.

## Why this is small

An earlier revision added a deadsnakes-PPA install for 3.13 — that was unnecessary (the base already has it) and introduced a supply-chain concern flagged by Copilot. Dropped via force-push. Verifying that `python3.13 --version` works directly from the base is enough.

## Verification

- `docker run --rm runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204 python3.13 --version` → `Python 3.13.11`
- Local `docker buildx build --build-arg PYTHON_VERSION=3.13 -f Dockerfile .` advances past `python3.13 --version` into the torch-install step (local QEMU runs hit transient network read errors on the 700 MB torch wheel; CI on native amd64 will handle it).
- Torch 2.9.1+cu128 cp313 wheel confirmed available at https://download.pytorch.org/whl/cu128/torch/

## Linear

[AE-3152](https://linear.app/runpod/issue/AE-3152) (child of AE-2827)

## Test plan

- [ ] CI matrix green for py3.13 × {gpu, cpu, lb, lb-cpu}
- [ ] After release-please merge, `runpod/flash:py3.13-{gpu,cpu,lb,lb-cpu}` exist on Docker Hub
- [ ] Pulled py3.13-gpu image startup version assertion prints `Python 3.13 OK`