### PR TITLE
fix(docker): SLS-377 install torchvision in GPU worker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ FROM runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204
 # Target Python version for the worker runtime.
 ARG PYTHON_VERSION=3.12
 ARG TORCH_VERSION=2.9.1+cu128
+# torchvision is NOT shipped by the runpod/pytorch base image (unlike torch and
+# torchaudio) and is auto-excluded from Flash build tarballs, so it must be
+# installed here. Pin to the release paired with TORCH_VERSION (torch 2.9.1 ->
+# torchvision 0.24.1); update both together on a torch bump. See SLS-377.
+ARG TORCHVISION_VERSION=0.24.1
 ARG TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128
 
 # Expose the target version to the running worker for startup validation.
@@ -75,9 +80,18 @@ RUN uv export --format requirements-txt --no-dev --no-hashes > requirements.txt 
 # must be provided here in the base image.
 RUN python -m pip install --no-cache-dir numpy
 
-# Verify torch, numpy, and the expected Python version are available.
+# Install torchvision for the active Python version.
+# The runpod/pytorch base ships torch/torchaudio but NOT torchvision, and Flash
+# build auto-excludes torchvision from tarballs, so it must be provided here.
+# Use the CUDA wheel index to stay aligned with the base image torch build.
+RUN python -m pip install --no-cache-dir \
+      --index-url ${TORCH_INDEX_URL} \
+      "torchvision==${TORCHVISION_VERSION}"
+
+# Verify torch, torchvision, numpy, and the expected Python version are available.
 RUN python -c "import sys; actual = f'{sys.version_info.major}.{sys.version_info.minor}'; expected = '${PYTHON_VERSION}'; assert actual == expected, f'Expected Python {expected}, got {actual}'; print(f'Python {actual} OK')" \
  && python -c "import torch; print(f'torch {torch.__version__} CUDA {torch.cuda.is_available()}')" \
+ && python -c "import torchvision; print(f'torchvision {torchvision.__version__}')" \
  && python -c "import numpy; print(f'numpy {numpy.__version__}')"
 
 CMD ["python", "handler.py"]


### PR DESCRIPTION
## Problem

A deployed Flash app importing `torchvision` fails at worker runtime with `ModuleNotFoundError` (customer escalation SLS-377, Zendesk #41953).

Root cause is a three-part gap:

1. `flash build`/`deploy` unconditionally strips torchvision from the deployment tarball — `SIZE_PROHIBITIVE_PACKAGES = {torch, torchvision, torchaudio, triton}`, merged as a set union, so there is no CLI flag to force-include it. The justification is that these are "already provided by the GPU base images (runpod/pytorch:*)".
2. That assumption is false for torchvision. Probing the current base image (`runpod/pytorch:1.0.3-cu1281-torch291-ubuntu2204`): torch, torchaudio, triton are present — **torchvision is not**.
3. The worker Dockerfile re-adds numpy explicitly (it hit the same gap) but had no torchvision backfill.

Net: stripped from tarball -> absent from base image -> never reinstalled -> import fails at runtime.

## Fix

Install torchvision in the GPU worker image, mirroring the existing numpy backfill:
- Pin `TORCHVISION_VERSION=0.24.1`, the release paired with the base torch 2.9.1 (bump both together on a torch upgrade).
- Install from the CUDA wheel index to stay CUDA-aligned.
- Add a build-time `import torchvision` assertion so a future torch bump that breaks the pairing fails the build, not the customer.

Not fixed by un-excluding torchvision from the tarball: its wheels are CUDA/platform-specific and depend on torch (which stays excluded), so bundling risks a CUDA mismatch and a second torch. The Dockerfile is the correct layer, consistent with the numpy precedent.

## Test plan

- `docker buildx build --platform linux/amd64 --build-arg PYTHON_VERSION=3.12 .` — succeeds; torchvision resolves to `0.24.1+cu128` with `torch==2.9.1` already satisfied (no torch re-pull).
- Build-time verify stage prints: `Python 3.12 OK`, `torch 2.9.1+cu128`, `torchvision 0.24.1+cu128`, `numpy 2.5.1`.
- `make quality-check` passes (14/14 handler tests + lint/format/typecheck/coverage).

## Follow-ups (out of scope here)

- **CPU images have the same gap** — the tarball exclusion is unconditional, so a CPU Flash app importing torchvision would also fail. Left for a separate change/ticket since CPU torchvision is a different wheel and adds image weight.
- The `SIZE_PROHIBITIVE_PACKAGES` comment in `flash` `build.py` ("already provided by the GPU base images") is now inaccurate for torchvision and should be corrected in a flash-side PR.