### PR TITLE
fix: unpin runpod-flash to released 1.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,8 @@ dependencies = [
     "huggingface_hub>=0.32.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
-    # TEMPORARY (SLS-360 coordinated release): this worker uses
-    # runpod_flash.runtime.module_loader, which is not in a published runpod-flash
-    # yet. Pin to the flash branch until runpod/flash#352 is merged and released,
-    # then REVERT to a released constraint (e.g. "runpod-flash>=1.18.0").
-    "runpod-flash @ git+https://github.com/runpod/flash.git@deanquinanola/sls-360-local-module-bundling",
+    # 1.19.0 is the first release containing runpod_flash.runtime.module_loader.
+    "runpod-flash>=1.19.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2557,8 +2557,8 @@ wheels = [
 
 [[package]]
 name = "runpod"
-version = "1.10.2.dev1"
-source = { git = "https://github.com/runpod/runpod-python?rev=main#08e07cb5dded275b1bab0451940433fe2a1c8244" }
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", extra = ["speedups"] },
     { name = "aiohttp-retry" },
@@ -2580,11 +2580,15 @@ dependencies = [
     { name = "urllib3" },
     { name = "watchdog" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/69/fd/62538e5497c4bc800bd62b0270de43f1d3d054eb58b9696ca548850da166/runpod-1.10.1.tar.gz", hash = "sha256:6d0ad5cdc36f5b7375968861f6973be82c923eb6e8c20bc658c48f398304c7b8", size = 580786 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/38f6ad5d15b0d5d843a1a87d89364c07b10c98a3542e604bf5e6259ace8a/runpod-1.10.1-py3-none-any.whl", hash = "sha256:1c12e32107cfd9f38c5d9c3d3f9c7f68fa7969bf99ea35f2fdc1fc03b174b90f", size = 334368 },
+]
 
 [[package]]
 name = "runpod-flash"
-version = "1.18.0"
-source = { git = "https://github.com/runpod/flash.git?rev=deanquinanola%2Fsls-360-local-module-bundling#0c8c90cefcddba3324a96a8474eb9986b174837d" }
+version = "1.19.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "pathspec" },
@@ -2595,6 +2599,10 @@ dependencies = [
     { name = "runpod" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/15/12b46f2f45391095683f070cab73a8ff0f49aa015b2d9466d3d50487926f/runpod_flash-1.19.0.tar.gz", hash = "sha256:70344dd7e2939a901a3c1c6eefe1a678a2f5533cb17f4b1239692bc278148952", size = 211122 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/7e/00665d3b0c47f52ffd43499a8ba7d5cd3adb5f0d74a04e8b094b84abe51d/runpod_flash-1.19.0-py3-none-any.whl", hash = "sha256:d7fc371e368be5504476a7ad915c0da965f0a0905c4a100017160168108020f4", size = 248661 },
 ]
 
 [[package]]
@@ -3062,7 +3070,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.4" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "runpod" },
-    { name = "runpod-flash", git = "https://github.com/runpod/flash.git?rev=deanquinanola%2Fsls-360-local-module-bundling" },
+    { name = "runpod-flash", specifier = ">=1.19.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 


### PR DESCRIPTION
## Problem

The scheduled **Bump Runtime Dependencies** workflow has been failing since 2026-07-24 ([latest run](https://github.com/runpod-workers/flash/actions/runs/30330390376)):

```
× Failed to download and build `runpod-flash @
  git+https://github.com/runpod/flash.git@deanquinanola/sls-360-local-module-bundling`
╰─▶ fatal: couldn't find remote ref
    refs/tags/deanquinanola/sls-360-local-module-bundling
```

`a44da63` (SLS-360) pinned `runpod-flash` to a flash feature branch as an explicitly temporary measure, because the worker imports `runpod_flash.runtime.module_loader` which had no published release. That branch was deleted when runpod/flash#352 merged on 2026-07-20, leaving a dangling ref.

This breaks any clean `uv lock` / `uv sync` on `main`, not just the bump workflow.

## Fix

`runpod-flash` 1.19.0 (released 2026-07-28, contains runpod/flash#352) is the first release shipping `runpod_flash/runtime/module_loader.py`, so the pin is replaced with the released constraint the original TODO called for.

- `pyproject.toml`: git ref -> `runpod-flash>=1.19.0`
- `uv.lock`: `runpod-flash` 1.18.0 (git) -> 1.19.0 (registry)
- `uv.lock`: `runpod` 1.10.2.dev1 (`runpod-python` git `main`) -> 1.10.1 (registry)

### Note on the `runpod` change

The flash branch pin was transitively dragging in `runpod` from `runpod-python` git `main` (an unpinned moving target). Dropping the flash git dep drops that too, so `runpod` now resolves from PyPI. This is intended — the worker should not ship a dependency on another repo's `main` — but it is a real change in what gets installed, and 1.10.1 is nominally lower than the `1.10.2.dev1` snapshot it replaces.

It does not go to 1.11.0 (current PyPI latest) because `--upgrade-package` only unpins the named package, and 1.11.0 requires newer pinned `boto3`/`fastapi`/`click`, so uv backtracks. The lock was generated with the bump workflow's own command, so the next scheduled run produces no further diff.

## Test plan

- [x] `uv lock --upgrade-package runpod-flash --upgrade-package runpod` — the failing command — now succeeds
- [x] `module_loader.py` confirmed present in the published 1.19.0 wheel
- [x] `from runpod_flash.runtime.module_loader import *` imports against installed 1.19.0
- [x] `make quality-check`: 283 passed, coverage 81.52% (threshold 35%), ruff + mypy clean
- [x] `make test-handler`: 14/14 passed
- [ ] Confirm the next **Bump Runtime Dependencies** run goes green after merge

## Follow-up

A CI guard rejecting `git+` dependencies in `pyproject.toml` on `main` would prevent recurrence — a branch pin both silently defeats the version-bumping workflow and hard-fails once the branch is deleted. Proposed as a separate PR.