### PR TITLE
fix(ci): support Python 3.10 in check_git_deps import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
     "mcp>=1.0.0",
     "typer>=0.12.0",
     "rich>=14.0.0",
+    # tomllib is stdlib only on 3.11+; scripts/check_git_deps.py needs the
+    # backport to run under the 3.10 CI matrix leg.
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/check_git_deps.py
+++ b/scripts/check_git_deps.py
@@ -22,9 +22,13 @@ depended-on version is published.
 from __future__ import annotations
 
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # tomllib is stdlib only on 3.11+; tomli is the drop-in backport
+    import tomli as tomllib
 
 GIT_MARKERS = ("git+", "git://")
 DEFAULT_PYPROJECT = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,6 +3056,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "rich" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
     { name = "types-requests" },
 ]
@@ -3085,6 +3086,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "types-requests", specifier = ">=2.25.0" },
 ]


### PR DESCRIPTION
## Problem

`scripts/check_git_deps.py` does an unconditional `import tomllib`. `tomllib` is stdlib only on **Python 3.11+**, so on the **3.10** test-matrix leg the module fails to import:

```
ModuleNotFoundError: No module named 'tomllib'
```

`docker-validation` depends on the `test` job, and `release` + every `docker-prod-*` publish job is gated on `docker-validation`. So this one 3.10 failure has **reddened every push to `main` since the check landed (#104, 2026-07-28)** and blocked release-please from cutting a release — meaning no base image has published since **v1.4.4 (April)**. The **SLS-377** torchvision fix (`#101`, merged 7/10) and later merges (e.g. SLS-360 `#100`) are stuck behind it.

It slipped review because **PR CI only runs the 3.11/3.12 matrix**, while **push-to-`main` runs the full 3.10–3.14 matrix**.

## Fix

- Guard the import: `tomllib` on 3.11+, `tomli` (drop-in backport) on <3.11.
- Add `tomli>=2.0.0; python_version < '3.11'` to the dev dependency group so it's present in the 3.10 env.

No behavior change — `tomli` exposes the same `loads` / `TOMLDecodeError` API the script uses.

## Test plan

Reproduced and verified under **Python 3.10.17** (the failing leg):

- **Before:** `pytest tests/unit/test_check_git_deps.py` → `ModuleNotFoundError: No module named 'tomllib'` (collection error), matching CI.
- **After:** `check_git_deps` tests **10 passed**; full suite **293 passed** @ 81% coverage; `ruff check` clean; `ruff format --check` clean; `mypy` clean; `python scripts/check_git_deps.py` exits 0.
- Sanity-checked on 3.12 (guard takes the `tomllib` path): green.

Unblocks a release, which republishes `runpod/flash:latest` / `py3.12-latest` with `torchvision 0.24.1+cu128` and closes SLS-377.